### PR TITLE
Added "html5lib" to BeautifulSoup calls

### DIFF
--- a/instant_coverage/optional.py
+++ b/instant_coverage/optional.py
@@ -74,7 +74,7 @@ class ExternalLinks(object):
             if response['Content-Type'].split(';')[0] != 'text/html':
                 continue
 
-            soup = BeautifulSoup(response.content)
+            soup = BeautifulSoup(response.content, "html5lib")
 
             for attribute in ['href', 'src', 'action']:
                 for prefix in ['http:', 'https:']:
@@ -192,7 +192,7 @@ class Spelling(object):
             if response['Content-Type'].split(';')[0] != 'text/html':
                 continue
 
-            text = BeautifulSoup(response.content).get_text()
+            text = BeautifulSoup(response.content, "html5lib").get_text()
 
             for word in re.findall(r'\b[^_\d\W]+\b', text, flags=re.UNICODE):
                 words[word].add(url)


### PR DESCRIPTION
Silences warning given by BeautifulSoup

UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html5lib"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
To get rid of this warning, change this:
 BeautifulSoup([your markup])
to this:
 BeautifulSoup([your markup], "html5lib")
